### PR TITLE
try to fix #1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/xyz/eclipseisoffline/eclipsestweakeroo/mixin/BarrierBlockMixin.java
+++ b/src/main/java/xyz/eclipseisoffline/eclipsestweakeroo/mixin/BarrierBlockMixin.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import xyz.eclipseisoffline.eclipsestweakeroo.config.AdditionalFeatureToggle;
 
 @Mixin(BarrierBlock.class)
-public abstract class BarrierBlockMixin extends Block implements Waterloggable {
+public abstract class BarrierBlockMixin extends Block{
 
     public BarrierBlockMixin(Settings settings) {
         super(settings);


### PR DESCRIPTION
Since the barrier waterlogged feature was introduced in 1.20.2, the mixin was adjusted to fix the crash (#1).